### PR TITLE
fix: invalid assignment errors

### DIFF
--- a/core/generateClass.ts
+++ b/core/generateClass.ts
@@ -41,7 +41,7 @@ export class GenerateCalss {
   }
 
   Map<String, dynamic> toJson() {
-\u0020\u0020\u0020\u0020Map<String, dynamic> data = <String, dynamic>{};${toJsonAnnotate}
+\u0020\u0020\u0020\u0020final Map<String, dynamic> data = <String, dynamic>{};${toJsonAnnotate}
 \u0020\u0020\u0020\u0020return data;
   }
 }`;

--- a/core/generateClass.ts
+++ b/core/generateClass.ts
@@ -41,7 +41,7 @@ export class GenerateCalss {
   }
 
   Map<String, dynamic> toJson() {
-\u0020\u0020\u0020\u0020final data = <String, dynamic>{};${toJsonAnnotate}
+\u0020\u0020\u0020\u0020final Map<String, dynamic> data = <String, dynamic>{};${toJsonAnnotate}
 \u0020\u0020\u0020\u0020return data;
   }
 }`;

--- a/core/generateClass.ts
+++ b/core/generateClass.ts
@@ -41,8 +41,8 @@ export class GenerateCalss {
   }
 
   Map<String, dynamic> toJson() {
-\u0020\u0020\u0020\u0020final _data = <String, dynamic>{};${toJsonAnnotate}
-\u0020\u0020\u0020\u0020return _data;
+\u0020\u0020\u0020\u0020final data = <String, dynamic>{};${toJsonAnnotate}
+\u0020\u0020\u0020\u0020return data;
   }
 }`;
 
@@ -119,7 +119,7 @@ export class GenerateCalss {
         break;
       case "Array":
         if (type.isArrayObject)
-          insertCode = `${key} = List.from(json['${rawKey}']${
+          insertCode = `${key} = List<dynamic>.from(json['${rawKey}']${
             type.nullable ? "??[]" : ""
           } as Iterable<dynamic>).map((e)=>${Utils._toCamelCase(
             rawKey,
@@ -127,7 +127,7 @@ export class GenerateCalss {
           )}.fromJson(e as Map<String, dynamic>)).toList();`;
         else {
           // 这里不清楚 List.castFrom 是否会对性能产生影响
-          insertCode = `${key} = List.castFrom<dynamic, ${
+          insertCode = `${key} = List<dynamic>.castFrom<dynamic, ${
             type.arrayType
           }>(json['${rawKey}']${type.nullable ? "??[]" : ""} as List<dynamic>);`;
         }
@@ -143,16 +143,16 @@ export class GenerateCalss {
 
   // toJson语句
   private _insertToJson(type: GenerateDartType, key: string, rawKey: string) {
-    let insertCode = `_data['${rawKey}'] = ${key};`;
+    let insertCode = `data['${rawKey}'] = ${key};`;
     switch (type.astType) {
       case "Object":
-        insertCode = `_data['${rawKey}'] = ${key}${
+        insertCode = `data['${rawKey}'] = ${key}${
           type.nullable ? "?" : ""
         }.toJson();`;
         break;
       case "Array": {
         if (type.isArrayObject)
-          insertCode = `_data['${rawKey}'] = ${key}.map((e)=>e.toJson()).toList();`;
+          insertCode = `data['${rawKey}'] = ${key}.map((e)=>e.toJson()).toList();`;
         break;
       }
       default:

--- a/core/generateClass.ts
+++ b/core/generateClass.ts
@@ -2,8 +2,8 @@
  * @Descripttion: 生成class
  * @Author: KuuBee
  * @Date: 2021-06-23 14:30:09
- * @LastEditors: KuuBee
- * @LastEditTime: 2021-09-02 16:51:57
+ * @LastEditors: Raphael ARABEYRE
+ * @LastEditTime: 2022-05-012 22:51:22
  */
 import parse, { ObjectNode, ValueNode } from "json-to-ast";
 import { GenerateDartType } from "./generateDartType";
@@ -103,7 +103,7 @@ export class GenerateCalss {
     rawKey: string
   ) {
     let insertCode = `${key} = ${
-      type.nullable ? "null" : `json['${rawKey}']`
+      type.nullable ? "null" : `json['${rawKey}']  as ${type.dartType}`
     };`;
     switch (type.astType) {
       case "Object":
@@ -111,29 +111,29 @@ export class GenerateCalss {
           insertCode = `${key} = ${Utils._toCamelCase(
             key,
             "defalut"
-          )}.fromJson(json['${rawKey}']);`;
+          )}.fromJson(json['${rawKey}'] as Map<String, dynamic>);`;
         else
           insertCode = `${key} = json['${rawKey}'] == null
           ? null
-          : ${Utils._toCamelCase(key, "defalut")}.fromJson(json['${rawKey}']);`;
+          : ${Utils._toCamelCase(key, "defalut")}.fromJson(json['${rawKey}'] as Map<String, dynamic>);`;
         break;
       case "Array":
         if (type.isArrayObject)
           insertCode = `${key} = List.from(json['${rawKey}']${
             type.nullable ? "??[]" : ""
-          }).map((e)=>${Utils._toCamelCase(
+          } as Iterable<dynamic>).map((e)=>${Utils._toCamelCase(
             rawKey,
             "defalut"
-          )}.fromJson(e)).toList();`;
+          )}.fromJson(e as Map<String, dynamic>)).toList();`;
         else {
           // 这里不清楚 List.castFrom 是否会对性能产生影响
           insertCode = `${key} = List.castFrom<dynamic, ${
             type.arrayType
-          }>(json['${rawKey}']${type.nullable ? "??[]" : ""});`;
+          }>(json['${rawKey}']${type.nullable ? "??[]" : ""} as List<dynamic>);`;
         }
         break;
       default:
-        insertCode = `${key} = json['${rawKey}'];`;
+        insertCode = `${key} = json['${rawKey}'] as ${type.dartType};`;
     }
     this.dart = this.dart.replace(
       fromJsonAnnotate,

--- a/core/generateClass.ts
+++ b/core/generateClass.ts
@@ -41,7 +41,7 @@ export class GenerateCalss {
   }
 
   Map<String, dynamic> toJson() {
-\u0020\u0020\u0020\u0020final Map<String, dynamic> data = <String, dynamic>{};${toJsonAnnotate}
+\u0020\u0020\u0020\u0020Map<String, dynamic> data = <String, dynamic>{};${toJsonAnnotate}
 \u0020\u0020\u0020\u0020return data;
   }
 }`;


### PR DESCRIPTION
add `as <row key's type>` in the `fromJson( )` methods, as the `json` map has dynamic value types but needed specific types, in `List.from( )` / `List.castFrom( )` and other places